### PR TITLE
Refactor setbl helper operations

### DIFF
--- a/XFoil.h
+++ b/XFoil.h
@@ -252,8 +252,13 @@ class XFoil {
   bool qiset();
   bool qvfue();
   bool qwcalc();
-  
+
   bool setbl();
+  void swapEdgeVelocities(SidePair<VectorXd>& usav);
+  void computeLeTeSensitivities(int ile1, int ile2, int ite1, int ite2,
+                                VectorXd& ule1_m, VectorXd& ule2_m,
+                                VectorXd& ute1_m, VectorXd& ute2_m);
+  void clearDerivativeVectors(VectorXd& u_m, VectorXd& d_m);
   bool setexp(double s[], double ds1, double smax, int nn);
 
   bool stepbl();


### PR DESCRIPTION
## Summary
- factor out repeated logic in `setbl`
- add helper utilities for swapping edge velocities, computing sensitivities and clearing derivative arrays

## Testing
- `cmake .. && make -j$(nproc)`
- `./test.exe`

------
https://chatgpt.com/codex/tasks/task_e_688a82cc86cc8332a99976e243bd809c