### PR TITLE
Refactor dil and dilw into dissipation module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(testExe
     ./model/boundary_layer.cpp
     ./model/math_util.cpp
     ./model/spline.cpp
+    ./model/coefficient/dissipation.cpp
     ./XFoil.cpp
     ./main.cpp
 )

--- a/XFoil.h
+++ b/XFoil.h
@@ -237,14 +237,6 @@ class XFoil {
   };
   EnvEnResult dampl(double hk, double th, double rt);
 
-  class DissipationResult {
-    public:
-    double di;
-    double di_hk;
-    double di_rt;
-  };
-  DissipationResult dil(double hk, double rt);
-  DissipationResult dilw(double hk, double rt);
   bool dslim(double &dstr, double thet, double msq, double hklim);
 
   bool gamqv();

--- a/model/coefficient/dissipation.cpp
+++ b/model/coefficient/dissipation.cpp
@@ -1,0 +1,47 @@
+#include "dissipation.hpp"
+#include <cmath>
+
+//---- laminar dissipation function
+
+dissipation::DissipationResult dissipation::dil(double hk, double rt) {
+  DissipationResult result;
+  if (hk < 4.0) {
+    result.di = (0.00205 * pow((4.0 - hk), 5.5) + 0.207) / rt;
+    result.di_hk = (-.00205 * 5.5 * pow((4.0 - hk), 4.5)) / rt;
+  } else {
+    double hkb = hk - 4.0;
+    double den = 1.0 + 0.02 * hkb * hkb;
+    result.di = (-.0016 * hkb * hkb / den + 0.207) / rt;
+    result.di_hk =
+        (-.0016 * 2.0 * hkb * (1.0 / den - 0.02 * hkb * hkb / den / den)) / rt;
+  }
+  result.di_rt = -(result.di) / rt;
+
+  return result;
+}
+
+//---- laminar wake dissipation function
+
+dissipation::DissipationResult dissipation::dilw(double hk, double rt) {
+  DissipationResult result;
+  boundary_layer::ThicknessShapeParameterResult hsl_result = boundary_layer::hsl(hk);
+  double rcd = 1.10 * (1.0 - 1.0 / hk) * (1.0 - 1.0 / hk) / hk;
+  double rcd_hk = -1.10 * (1.0 - 1.0 / hk) * 2.0 / hk / hk / hk - rcd / hk;
+
+  result.di = 2.0 * rcd / (hsl_result.hs * rt);
+  result.di_hk = 2.0 * rcd_hk / (hsl_result.hs * rt) -
+                 ((result.di) / hsl_result.hs) * hsl_result.hs_hk;
+  result.di_rt = -(result.di) / rt -
+                 ((result.di) / hsl_result.hs) * hsl_result.hs_rt;
+
+  return result;
+}
+
+dissipation::DissipationResult dissipation::getDissipation(
+    double hk, double rt, XFoil::FlowRegimeEnum flowRegimeType) {
+  if (flowRegimeType == XFoil::FlowRegimeEnum::Wake) {
+    return dilw(hk, rt);
+  }
+  return dil(hk, rt);
+}
+

--- a/model/coefficient/dissipation.hpp
+++ b/model/coefficient/dissipation.hpp
@@ -1,0 +1,16 @@
+#include "../../XFoil.h"
+
+class dissipation {
+public:
+  class DissipationResult {
+  public:
+    double di;
+    double di_hk;
+    double di_rt;
+  };
+  static DissipationResult dil(double hk, double rt);
+  static DissipationResult dilw(double hk, double rt);
+  static DissipationResult getDissipation(double hk, double rt,
+                                          XFoil::FlowRegimeEnum flowRegimeType);
+};
+


### PR DESCRIPTION
## Summary
- Extract laminar and wake dissipation calculations into new `model/coefficient/dissipation` module
- Use new dissipation functions from `XFoil` and remove old implementations
- Register dissipation source in CMake build

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/test.exe`
- `g++ model/math_util.cpp model/math_util_test.cpp -lgtest -lgtest_main -pthread` (fails: Eigen/Core and gtest/gtest.h not found)
- `apt-get update` (fails: repository 403)


------
https://chatgpt.com/codex/tasks/task_e_68933ad5ba888332bfc17c6ce7b57869