### PR TITLE
Refactor dil and dilw into dissipation module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(testExe
     ./model/boundary_layer.cpp
     ./model/math_util.cpp
     ./model/spline.cpp
+    ./model/coefficient/dissipation.cpp
     ./XFoil.cpp
     ./main.cpp
 )

--- a/XFoil.h
+++ b/XFoil.h
@@ -237,14 +237,6 @@ class XFoil {
   };
   EnvEnResult dampl(double hk, double th, double rt);
 
-  class DissipationResult {
-    public:
-    double di;
-    double di_hk;
-    double di_rt;
-  };
-  DissipationResult dil(double hk, double rt);
-  DissipationResult dilw(double hk, double rt);
   bool dslim(double &dstr, double thet, double msq, double hklim);
 
   bool gamqv();

--- a/model/coefficient/dissipation.cpp
+++ b/model/coefficient/dissipation.cpp
@@ -1,0 +1,47 @@
+#include "dissipation.hpp"
+#include <cmath>
+
+//---- laminar dissipation function
+
+dissipation::DissipationResult dissipation::dil(double hk, double rt) {
+  DissipationResult result;
+  if (hk < 4.0) {
+    result.di = (0.00205 * pow((4.0 - hk), 5.5) + 0.207) / rt;
+    result.di_hk = (-.00205 * 5.5 * pow((4.0 - hk), 4.5)) / rt;
+  } else {
+    double hkb = hk - 4.0;
+    double den = 1.0 + 0.02 * hkb * hkb;
+    result.di = (-.0016 * hkb * hkb / den + 0.207) / rt;
+    result.di_hk =
+        (-.0016 * 2.0 * hkb * (1.0 / den - 0.02 * hkb * hkb / den / den)) / rt;
+  }
+  result.di_rt = -(result.di) / rt;
+
+  return result;
+}
+
+//---- laminar wake dissipation function
+
+dissipation::DissipationResult dissipation::dilw(double hk, double rt) {
+  DissipationResult result;
+  boundary_layer::ThicknessShapeParameterResult hsl_result = boundary_layer::hsl(hk);
+  double rcd = 1.10 * (1.0 - 1.0 / hk) * (1.0 - 1.0 / hk) / hk;
+  double rcd_hk = -1.10 * (1.0 - 1.0 / hk) * 2.0 / hk / hk / hk - rcd / hk;
+
+  result.di = 2.0 * rcd / (hsl_result.hs * rt);
+  result.di_hk = 2.0 * rcd_hk / (hsl_result.hs * rt) -
+                 ((result.di) / hsl_result.hs) * hsl_result.hs_hk;
+  result.di_rt = -(result.di) / rt -
+                 ((result.di) / hsl_result.hs) * hsl_result.hs_rt;
+
+  return result;
+}
+
+dissipation::DissipationResult dissipation::getDissipation(
+    double hk, double rt, XFoil::FlowRegimeEnum flowRegimeType) {
+  if (flowRegimeType == XFoil::FlowRegimeEnum::Wake) {
+    return dilw(hk, rt);
+  }
+  return dil(hk, rt);
+}
+

--- a/model/coefficient/dissipation.hpp
+++ b/model/coefficient/dissipation.hpp
@@ -1,0 +1,16 @@
+#include "../../XFoil.h"
+
+class dissipation {
+public:
+  class DissipationResult {
+  public:
+    double di;
+    double di_hk;
+    double di_rt;
+  };
+  static DissipationResult dil(double hk, double rt);
+  static DissipationResult dilw(double hk, double rt);
+  static DissipationResult getDissipation(double hk, double rt,
+                                          XFoil::FlowRegimeEnum flowRegimeType);
+};
+

--- a/model/coefficient/dissipation_test.cpp
+++ b/model/coefficient/dissipation_test.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+
+#include "dissipation.hpp"
+
+TEST(DissipationTest, DilBelow4) {
+    double hk = 3.0;
+    double rt = 1e5;
+    auto res = dissipation::dil(hk, rt);
+    EXPECT_NEAR(2.0904999999999997e-06, res.di, 1e-12);
+    EXPECT_NEAR(-1.1275e-07, res.di_hk, 1e-12);
+    EXPECT_NEAR(-2.0904999999999998e-11, res.di_rt, 1e-17);
+}
+
+TEST(DissipationTest, DilAbove4) {
+    double hk = 5.0;
+    double rt = 1e5;
+    auto res = dissipation::dil(hk, rt);
+    EXPECT_NEAR(2.0543137254901963e-06, res.di, 1e-12);
+    EXPECT_NEAR(-3.0757400999615534e-08, res.di_hk, 1e-12);
+    EXPECT_NEAR(-2.0543137254901964e-11, res.di_rt, 1e-17);
+}
+
+TEST(DissipationTest, DilwWake) {
+    double hk = 5.0;
+    double rt = 1e5;
+    auto res = dissipation::dilw(hk, rt);
+    EXPECT_NEAR(1.841404463247928e-06, res.di, 1e-12);
+    EXPECT_NEAR(-5.568121217349049e-07, res.di_hk, 1e-12);
+    EXPECT_NEAR(-1.8414044632479282e-11, res.di_rt, 1e-17);
+}
+
+TEST(DissipationTest, GetDissipationFlowRegime) {
+    double hk = 5.0;
+    double rt = 1e5;
+    auto lam = dissipation::getDissipation(hk, rt, XFoil::FlowRegimeEnum::Laminar);
+    auto lamExp = dissipation::dil(hk, rt);
+    EXPECT_DOUBLE_EQ(lamExp.di, lam.di);
+    EXPECT_DOUBLE_EQ(lamExp.di_hk, lam.di_hk);
+    EXPECT_DOUBLE_EQ(lamExp.di_rt, lam.di_rt);
+
+    auto wake = dissipation::getDissipation(hk, rt, XFoil::FlowRegimeEnum::Wake);
+    auto wakeExp = dissipation::dilw(hk, rt);
+    EXPECT_DOUBLE_EQ(wakeExp.di, wake.di);
+    EXPECT_DOUBLE_EQ(wakeExp.di_hk, wake.di_hk);
+    EXPECT_DOUBLE_EQ(wakeExp.di_rt, wake.di_rt);
+}
+
+int main() {
+    testing::InitGoogleTest();
+    return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
## Summary
- Extract laminar and wake dissipation calculations into new `model/coefficient/dissipation` module
- Use new dissipation functions from `XFoil` and remove old implementations
- Register dissipation source in CMake build
- Add unit tests for laminar, wake, and flow-regime dissipation helpers

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/test.exe`
- `g++ model/coefficient/dissipation.cpp model/coefficient/dissipation_test.cpp model/boundary_layer.cpp model/math_util.cpp -lgtest -lgtest_main -pthread -I/usr/include/eigen3` *(fails: gtest/gtest.h not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68933ad5ba888332bfc17c6ce7b57869