### PR TITLE
Remove redundant comset calls in specal()

### DIFF
--- a/XFoil.cpp
+++ b/XFoil.cpp
@@ -3857,8 +3857,6 @@ bool XFoil::specal() {
   //---- set corresponding  m(clm), re(clm)
   minf_clm = getActualMach(clm, mach_type);
 
-  comset();
-
   //---- set corresponding cl(m)
   clcalc(cmref);
   //---- iterate on clm
@@ -3886,7 +3884,6 @@ bool XFoil::specal() {
     }
 
     //------ set new cl(m)
-    comset();
     clcalc(cmref);
 
     if (fabs(dclm) <= 1.0e-6) {


### PR DESCRIPTION
## Summary
- streamline specal() by eliminating two unnecessary `comset()` calls
- keep final `comset()` so downstream routines use updated compressibility parameters

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_6899a54b5b448332b7a51de3ad4f371d