### PR TITLE
refactor: extract foil geometry

### DIFF
--- a/XFoil.cpp
+++ b/XFoil.cpp
@@ -30,6 +30,7 @@
 #include <numbers>
 using namespace Eigen;
 
+
 // determinant
 double cross2(const Eigen::Vector2d &a, const Eigen::Vector2d &b) {
   return a[0] * b[1] - a[1] * b[0];
@@ -39,7 +40,20 @@ bool XFoil::s_bCancel = false;
 double XFoil::vaccel = 0.01;
 const int INDEX_START_WITH = 1;
 
-XFoil::XFoil() {
+XFoil::XFoil()
+    : foil(),
+      n(foil.n),
+      points(foil.points),
+      normal_vectors(foil.normal_vectors),
+      dpoints_ds(foil.dpoints_ds),
+      spline_length(foil.spline_length),
+      point_le(foil.point_le),
+      point_te(foil.point_te),
+      chord(foil.chord),
+      sle(foil.sle),
+      cmref(foil.cmref),
+      surface_vortex(foil.surface_vortex),
+      apanel(foil.apanel) {
   m_pOutStream = nullptr;
 
   // fortran seems to initializes variables to 0
@@ -5454,3 +5468,4 @@ bool XFoil::isValidFoilAngles(Matrix2Xd points) {
 bool XFoil::isValidFoilPointSize(Matrix2Xd points) {
   return points.cols() >= 3 + INDEX_START_WITH;
 }
+

--- a/XFoil.h
+++ b/XFoil.h
@@ -52,6 +52,7 @@ Harold Youngren. See http://raphael.mit.edu/xfoil for more information.
 #include "model/boundary_layer.hpp"
 #include "model/psi_result.hpp"
 #include "xfoil_params.h"
+#include "src/Foil.h"
 
 using namespace std;
 using namespace Eigen;
@@ -305,8 +306,6 @@ class XFoil {
 
   double clspec;
 
-  Matrix2Xd normal_vectors;
-
   double cl, cm, cd, acrit;
   VectorXd cpi, cpv;
   double xcp;
@@ -320,22 +319,31 @@ class XFoil {
   double minf1;
   bool lblini, lipan;
   
-  int n;
+  Foil foil;
+  int &n;
+  Matrix2Xd &points; // formerly x,y
+  Matrix2Xd &normal_vectors;
+  Matrix2Xd &dpoints_ds; // formerly xp, yp
+  VectorXd &spline_length;
+  Vector2d &point_le;
+  Vector2d &point_te;
+  double &chord;
+  double &sle;
+  Vector2d &cmref;
+  Matrix2Xd &surface_vortex;
+  VectorXd &apanel;
+
   SidePair<VectorXi> ipan, isys;
   SidePair<int> iblte, nbl;
-  
-  Matrix2Xd points; //formerly x,y
+
   SidePair<double> xstrip;
-  
-  Vector2d cmref;
+
   double tklam; // karman-tsien parameter minf^2 / [1 + sqrt[1-minf^2]]^2 <- Prandtl-Glauert-Ackeret rule ?
   double tkl_msq;
-  Matrix2Xd dpoints_ds; //formerly xp, yp
-  VectorXd spline_length;
   double dtor;
 
   SidePair<VectorXd> thet, ctau, dstr, uedg, ctq;
-  SidePair<VectorXd> xssi, uinv, uinv_a, mass, vti;  
+  SidePair<VectorXd> xssi, uinv, uinv_a, mass, vti;
   SidePair<int> itran; // bl array index of transition interval
 
  public: //private:
@@ -355,10 +363,7 @@ class XFoil {
   int nsys;
   VectorXd snew;
 
-  double sle;
-  Vector2d point_le;
-  Vector2d point_te;
-  double chord, wgap[IWX], waklen;
+  double wgap[IWX], waklen;
   int nw, i_stagnation;
 
 
@@ -366,9 +371,7 @@ class XFoil {
   double gamma, gamm1;
 
 
-  Matrix2Xd surface_vortex;
   Matrix2Xd gamu;
-  VectorXd apanel;
   double sst, sst_go, sst_gp, gamte, sigte;
   double dste, aste;
   Matrix2Xd qinvu;

--- a/XFoilTest.cpp
+++ b/XFoilTest.cpp
@@ -53,16 +53,16 @@ protected:
       std::cout << "Initialization error!" << std::endl;
     }
 
-    for (int i=1; i<=foil->n; i++) {
-      Vector2d plot = foil->points.row(i);
+    for (int i = 1; i <= foil->foil.n; i++) {
+      Vector2d plot = foil->foil.points.row(i);
       plots.push_back(plot);
     }
-  }  
+  }
 };
 
 TEST_F(DatGoogleTest, test_cang) {
   //when
-  double actual = foil->cang(foil->points);
+  double actual = foil->cang(foil->foil.points);
 
   //then
   ASSERT_DOUBLE_EQ(9.9742071999702819, actual);

--- a/src/Foil.h
+++ b/src/Foil.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "Eigen/Core"
+#include "Eigen/Dense"
+
+using namespace Eigen;
+
+class Foil {
+ public:
+  int n;
+  Matrix2Xd points;
+  Matrix2Xd normal_vectors;
+  Matrix2Xd dpoints_ds;
+  VectorXd spline_length;
+  Vector2d point_le;
+  Vector2d point_te;
+  double chord;
+  double sle;
+  Vector2d cmref;
+  Matrix2Xd surface_vortex;
+  VectorXd apanel;
+
+  Foil()
+      : n(0),
+        chord(0.0),
+        sle(0.0),
+        cmref(Vector2d{0.25, 0.0}) {}
+};
+


### PR DESCRIPTION
## Summary
- introduce `Foil` class to encapsulate airfoil geometry data
- update `XFoil` to hold a `Foil` instance and expose geometry via references
- adapt tests to use new geometry container

## Testing
- `cmake --build .`
- `./test.exe`

------
https://chatgpt.com/codex/tasks/task_e_689b74114e208332ab1e63206506c4cf